### PR TITLE
Lobby Bugs have been fixed

### DIFF
--- a/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyRequestMessageTest.kt
+++ b/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyRequestMessageTest.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyResponseMessageTest.kt
+++ b/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyResponseMessageTest.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyUpdateMessageTest.kt
+++ b/app/src/androidTest/java/at/aau/serg/sdlapp/network/messaging/LobbyUpdateMessageTest.kt
@@ -1,0 +1,49 @@
+package at.aau.serg.sdlapp.network.messaging
+
+import org.junit.Test
+import org.junit.Assert.*
+
+
+class LobbyUpdateMessageTest {
+    @Test
+    fun testInitialization() {
+        val message = LobbyUpdateMessage(
+            player1 = "Alice",
+            player2 = "Bob",
+            player3 = "Charlie",
+            player4 = "Dana",
+            isStarted = true
+        )
+
+        assertEquals("Alice", message.player1)
+        assertEquals("Bob", message.player2)
+        assertEquals("Charlie", message.player3)
+        assertEquals("Dana", message.player4)
+        assertTrue(message.isStarted)
+    }
+
+    @Test
+    fun testEquality() {
+        val m1 = LobbyUpdateMessage("A", "B", "C", "D", false)
+        val m2 = LobbyUpdateMessage("A", "B", "C", "D", false)
+
+        assertEquals(m1, m2)
+    }
+
+    @Test
+    fun testCopy() {
+        val original = LobbyUpdateMessage("A", "B", "C", "D", true)
+        val copy = original.copy()
+
+        assertEquals(original, copy)
+        assertNotSame(original, copy)
+    }
+
+    @Test
+    fun testInequality() {
+        val m1 = LobbyUpdateMessage("A", "B", "C", "D", false)
+        val m2 = LobbyUpdateMessage("A", "B", "C", "D", true)
+
+        assertNotEquals(m1, m2)
+    }
+}

--- a/app/src/main/java/at/aau/serg/sdlapp/network/MyStomp.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/MyStomp.kt
@@ -143,7 +143,7 @@ class MyStomp(private val callback: (String) -> Unit) {
 
     suspend fun sendLobbyLeave(playerName: String, lobbyID: String) {
         val session = getSession() ?: run {
-            sendToMainThread("Not connected")
+            sendToMainThread("Keine Verbindung aktiv")
             return
         }
         try{
@@ -159,7 +159,7 @@ class MyStomp(private val callback: (String) -> Unit) {
 
     suspend fun sendLobbyCreate(playerName: String): String? = withContext(Dispatchers.IO) {
         val session : StompSession = getSession() ?: run {
-            sendToMainThread("Not connected")
+            sendToMainThread("Keine Verbindung aktiv")
             return@withContext null
         }
         try {
@@ -191,7 +191,7 @@ class MyStomp(private val callback: (String) -> Unit) {
     suspend fun sendLobbyJoin(playerName: String, lobbyID: String): LobbyResponseMessage? =
         withContext(Dispatchers.IO) {
             val session = getSession() ?: run {
-                sendToMainThread("Not connected")
+                sendToMainThread("Keine Verbindung aktiv")
                 return@withContext null
             }
             try {

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/JobMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/JobMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class JobMessage(
     val jobId: Int,

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/JobRequestMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/JobRequestMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class JobRequestMessage(
     val playerName: String,

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyRequestMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyRequestMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class LobbyRequestMessage(
     val playerName : String

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyResponseMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyResponseMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class LobbyResponseMessage(
     val lobbyId : String,

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyUpdateMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/LobbyUpdateMessage.kt
@@ -1,0 +1,9 @@
+package at.aau.serg.sdlapp.network.messaging
+
+data class LobbyUpdateMessage(
+    val player1 : String,
+    val player2 : String,
+    val player3 : String,
+    val player4 : String,
+    val isStarted : Boolean
+)

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/MoveMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/MoveMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 import com.google.gson.annotations.SerializedName
 

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/OutputMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/OutputMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class OutputMessage(
     val playerName: String,

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/PlayerListMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/PlayerListMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 /**
  * Nachricht vom Server mit Liste aller aktiven Spieler

--- a/app/src/main/java/at/aau/serg/sdlapp/network/messaging/StompMessage.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/messaging/StompMessage.kt
@@ -1,4 +1,4 @@
-package at.aau.serg.sdlapp.network
+package at.aau.serg.sdlapp.network.messaging
 
 data class StompMessage(
     val playerName: String,

--- a/app/src/main/java/at/aau/serg/sdlapp/network/viewModels/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/viewModels/LobbyViewModel.kt
@@ -25,7 +25,8 @@ class LobbyViewModel(
 
     fun initialize(lobbyId: String, currentPlayer: String){
         currentLobbyId = lobbyId
-        _players.value = listOf(currentPlayer)
+        // Setze die Spielerliste initial leer, damit das erste LobbyUpdateMessage die Liste korrekt setzt
+        _players.value = emptyList()
         startObserving(lobbyId)
     }
 

--- a/app/src/main/java/at/aau/serg/sdlapp/network/viewModels/LobbyViewModel.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/network/viewModels/LobbyViewModel.kt
@@ -33,10 +33,21 @@ class LobbyViewModel(
         updatesJob?.cancel()
         updatesJob = viewModelScope.launch {
             try{
-                session.subscribeText("/topic/$lobbyId").collect { payload ->
-                    val json = JSONObject(payload)
+            session.subscribeText("/topic/$lobbyId").collect { payload ->
+                val json = JSONObject(payload)
+                // Prüfe auf vollständige Spielerliste (LobbyUpdateMessage)
+                if (json.has("player1")) {
+                    val players = listOfNotNull(
+                        json.optString("player1").takeIf { !it.isNullOrBlank() },
+                        json.optString("player2").takeIf { !it.isNullOrBlank() },
+                        json.optString("player3").takeIf { !it.isNullOrBlank() },
+                        json.optString("player4").takeIf { !it.isNullOrBlank() }
+                    )
+                    _players.value = players
+                }
+                // Prüfe auf einzelne Join-Response (LobbyResponseMessage)
+                else if (json.has("playerName")) {
                     val playerName = json.getString("playerName")
-
                     _players.update { currentPlayers ->
                         if(!currentPlayers.contains(playerName)) {
                             currentPlayers + playerName
@@ -45,8 +56,9 @@ class LobbyViewModel(
                         }
                     }
                 }
+            }
             } catch (e: Exception) {
-                Log.e("LobbyVidwModel", "Error in updates flow", e)
+                Log.e("LobbyViewModel", "Error in updates flow", e)
             }
         }
     }

--- a/app/src/main/java/at/aau/serg/sdlapp/test/MoveTest.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/test/MoveTest.kt
@@ -1,6 +1,5 @@
 package at.aau.serg.sdlapp.test
 
-import at.aau.serg.sdlapp.network.MoveMessage
 import at.aau.serg.sdlapp.network.MyStomp
 
 /**

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/BoardActivity.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/BoardActivity.kt
@@ -8,20 +8,17 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.ComponentActivity
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import at.aau.serg.sdlapp.R
 import at.aau.serg.sdlapp.model.player.PlayerManager
-import at.aau.serg.sdlapp.network.MoveMessage
+import at.aau.serg.sdlapp.network.messaging.MoveMessage
 import at.aau.serg.sdlapp.ui.board.BoardFigureManager
 import at.aau.serg.sdlapp.ui.board.BoardMoveManager
 import at.aau.serg.sdlapp.ui.board.BoardNetworkManager
 import at.aau.serg.sdlapp.ui.board.BoardUIManager
 import com.otaliastudios.zoom.ZoomLayout
-import androidx.compose.ui.platform.ComposeView
 
 /**
  * Die BoardActivity ist die Hauptaktivität des Spiels und verwaltet die

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/HomeScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/HomeScreenActivity.kt
@@ -54,7 +54,6 @@ class HomeScreenActivity : ComponentActivity() {
         playerName = intent.getStringExtra("playerName") ?: "Spieler"
 
         viewModel.initializeStomp { message ->
-            Log.d("Debugging", "got here")
             runOnUiThread {
                 Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
             }
@@ -173,15 +172,12 @@ class HomeScreenActivity : ComponentActivity() {
                                             response?.message ?: "Beitritt fehlgeschlagen"
                                         )
                                     }
-
                                 }
                             }
                         )
-
                     )
                 }
             }
-
         }
     }
 

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/HomeScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/HomeScreenActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,6 +71,9 @@ class HomeScreenActivity : ComponentActivity() {
         var showTextField by remember { mutableStateOf(false) }
         var lobbyId by remember { mutableStateOf("") }
         val context = LocalContext.current
+        var showWarning by remember { mutableStateOf(false) }
+        val focusRequester = remember { FocusRequester() }
+        val focusManager = LocalFocusManager.current
 
         Column(modifier = Modifier.fillMaxSize()) {
             Text(
@@ -125,7 +129,7 @@ class HomeScreenActivity : ComponentActivity() {
                 Text("Lobby beitreten")
             }
             if (showTextField) {
-                val focusRequester = remember { FocusRequester() }
+
 
                 LaunchedEffect(showTextField) {
                     delay(100) //bis Textfield im Layout ist
@@ -139,7 +143,10 @@ class HomeScreenActivity : ComponentActivity() {
                 ) {
                     TextField(
                         value = lobbyId,
-                        onValueChange = { lobbyId = it },
+                        onValueChange = {
+                            lobbyId = it
+                            showWarning = false // Fehlermeldung zurücksetzen, wenn Nutzer tippt
+                        },
                         placeholder = {
                             Text(
                                 text = "Lobby-ID eingeben",
@@ -168,26 +175,26 @@ class HomeScreenActivity : ComponentActivity() {
                                         }
                                         context.startActivity(intent)
                                     } else {
-                                        showToast(
-                                            response?.message ?: "Beitritt fehlgeschlagen"
-                                        )
+                                        Log.e("Lobby-Beitritt", response?.message ?: "Beitritt fehlgeschlagen")
+                                        withContext(Dispatchers.Main) { showWarning = true }
                                     }
                                 }
                             }
                         )
                     )
+                    if (showWarning) {
+                        LaunchedEffect(showWarning) {
+                            focusManager.clearFocus()
+                        }
+                        Text(
+                            text = "Lobby-ID existiert nicht",
+                            fontSize = 15.sp,
+                            color = Color.Red,
+                            modifier = Modifier.align(Alignment.CenterHorizontally)
+                        )
+                    }
                 }
             }
-        }
-    }
-
-    //function to switch to lobby screen, using lobby id as parameter
-    @Composable
-    fun StartLobbyScreen(lobbyid: String?) {
-        val context = LocalContext.current
-        Intent(context, LobbyActivity::class.java).apply {
-            intent.putExtra("Lobby-ID", lobbyid)
-            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/JobSelectionActivity.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/JobSelectionActivity.kt
@@ -6,7 +6,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import at.aau.serg.sdlapp.R
-import at.aau.serg.sdlapp.network.JobMessage
+import at.aau.serg.sdlapp.network.messaging.JobMessage
 import at.aau.serg.sdlapp.network.MyStomp
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/board/BoardMoveManager.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/board/BoardMoveManager.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.widget.Toast
 import at.aau.serg.sdlapp.model.board.BoardData
 import at.aau.serg.sdlapp.model.player.PlayerManager
-import at.aau.serg.sdlapp.network.MoveMessage
+import at.aau.serg.sdlapp.network.messaging.MoveMessage
 import at.aau.serg.sdlapp.network.MyStomp
 
 /**

--- a/app/src/main/java/at/aau/serg/sdlapp/ui/board/BoardNetworkManager.kt
+++ b/app/src/main/java/at/aau/serg/sdlapp/ui/board/BoardNetworkManager.kt
@@ -3,9 +3,8 @@ package at.aau.serg.sdlapp.ui.board
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.widget.Toast
 import at.aau.serg.sdlapp.model.player.PlayerManager
-import at.aau.serg.sdlapp.network.MoveMessage
+import at.aau.serg.sdlapp.network.messaging.MoveMessage
 import at.aau.serg.sdlapp.network.MyStomp
 import java.util.Timer
 import java.util.TimerTask

--- a/app/src/test/java/at/aau/serg/sdlapp/network/OutputMessageTest.kt
+++ b/app/src/test/java/at/aau/serg/sdlapp/network/OutputMessageTest.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.sdlapp.network
 
+import at.aau.serg.sdlapp.network.messaging.OutputMessage
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 

--- a/app/src/test/java/at/aau/serg/sdlapp/network/StompMessageTest.kt
+++ b/app/src/test/java/at/aau/serg/sdlapp/network/StompMessageTest.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.sdlapp.network
 
+import at.aau.serg.sdlapp.network.messaging.StompMessage
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
fixes issue #63 
I have fixed the issue, that the player lists that were displayed in the lobby activity were not the real backend data. 
Backend now sends updates after every change (create, join and leave) to keep player list updated. 

Also added error handling: If the lobby id the user wants to join does not exist, a error message is displayed (see screenshot) and the user can try again. Previously, the app crashed. 

![image](https://github.com/user-attachments/assets/ac1ee057-c7c2-4d4f-882f-49a6578c3e8c)
